### PR TITLE
[상품 등록] API 연동

### DIFF
--- a/src/components/items/additem/ChooseImgFile.tsx
+++ b/src/components/items/additem/ChooseImgFile.tsx
@@ -42,7 +42,7 @@ function ChooseImgFile({ imgFile, setImgFile }: ImgFileProps) {
         console.error(err);
       },
     });
-  }, [previewUrl]);
+  }, [previewUrl, uploadImg, setImgFile]);
 
   const handlePreventionClick = (e: MouseEvent) => {
     if (imgFile) {

--- a/src/components/items/additem/ChooseImgFile.tsx
+++ b/src/components/items/additem/ChooseImgFile.tsx
@@ -3,19 +3,46 @@ import UploadImg from "@/public/assets/images/items/upload.svg";
 import ImgPreview from "./ImgPreview";
 import { ImgFileProps } from "./types";
 import styles from "./additem.module.css";
+import { usePostProductImg } from "@/src/hooks/usePostProductImg";
 
 // 상품 이미지 등록
 function ChooseImgFile({ imgFile, setImgFile }: ImgFileProps) {
-  const [preview, setPreview] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<Blob>();
+  const [previewImg, setPreviewImg] = useState("");
   const [isImgChk, setIsImgChk] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleGetImg = async (e: ChangeEvent<HTMLInputElement>) => {
     const nextValue = (e?.target as HTMLInputElement).files![0];
-    setImgFile(nextValue);
+    setPreviewUrl(nextValue);
+
     // 같은 파일을 재업로드 할 경우 event가 trigger되지 않는 버그 방지
     e.target.value = "";
   };
+
+  // 이미지 미리보기
+  useEffect(() => {
+    if (!previewUrl) return;
+
+    const nextPreview = URL.createObjectURL(previewUrl);
+    setPreviewImg(nextPreview);
+  }, [previewUrl]);
+
+  // 프로젝트 저장 URL 획득
+  const { mutate: uploadImg } = usePostProductImg();
+
+  useEffect(() => {
+    if (!previewUrl) return;
+
+    uploadImg(previewUrl, {
+      onSuccess: (data) => {
+        setImgFile(data);
+      },
+      onError: (err) => {
+        console.error(err);
+      },
+    });
+  }, [previewUrl]);
 
   const handlePreventionClick = (e: MouseEvent) => {
     if (imgFile) {
@@ -28,15 +55,9 @@ function ChooseImgFile({ imgFile, setImgFile }: ImgFileProps) {
 
   const handleDeleteClick = () => {
     setIsImgChk(false);
-    setImgFile(null);
-    setPreview("");
+    setImgFile("");
+    setPreviewImg("");
   };
-
-  useEffect(() => {
-    if (!imgFile) return;
-    const nextPreview = URL.createObjectURL(imgFile);
-    setPreview(nextPreview);
-  }, [imgFile]);
 
   return (
     <div className={`${styles.inputContainer} ${styles.fileBox}`}>
@@ -55,15 +76,15 @@ function ChooseImgFile({ imgFile, setImgFile }: ImgFileProps) {
             type="file"
             className={styles.btnImgUpload}
             accept=".jpg, .png"
-            onChange={handleChange}
+            onChange={handleGetImg}
             ref={inputRef}
             onClick={handlePreventionClick}
           />
         </div>
-        {preview && (
+        {previewImg && (
           <div className={`${styles.coverTile} ${styles.thumbnail}`}>
             <ImgPreview
-              preview={preview}
+              preview={previewImg}
               handleDeleteClick={handleDeleteClick}
             />
           </div>

--- a/src/components/items/additem/InputContainer.tsx
+++ b/src/components/items/additem/InputContainer.tsx
@@ -54,7 +54,8 @@ function InputContainer({ setValues }: InitialValues) {
 
   // onKeyDown 이벤트 키가 Enter와 일치하면 실행
   const activeEnter = (e: KeyboardEvent<HTMLInputElement>) => {
-    const specialCharRegex = /[ \{\}\[\]\/?.,;:|\)*~`!^\+┼<>@\#$%&\'\"\\\(\=]/gi;
+    const specialCharRegex =
+      /[ \{\}\[\]\/?.,;:|\)*~`!^\+┼<>@\#$%&\'\"\\\(\=]/gi;
     // onKeyDown 이벤트의 한글 입력 시 이벤트가 두 번 호출 되는 버그 방지
     if (e.nativeEvent.isComposing) {
       return;
@@ -90,7 +91,7 @@ function InputContainer({ setValues }: InitialValues) {
       <div className={styles.inputContainer}>
         <p className={styles.inputTitle}>상품명</p>
         <input
-          name="title"
+          name="name"
           type="text"
           placeholder="상품명을 입력해주세요"
           onChange={handleInputChange}

--- a/src/components/items/additem/UploadForm.tsx
+++ b/src/components/items/additem/UploadForm.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect, FormEvent } from "react";
+import { useState, useEffect } from "react";
 import InputContainer from "./InputContainer";
 import ChooseImgFile from "./ChooseImgFile";
 import styles from "./additem.module.css";
+import { usePostProduct } from "@/src/hooks/usePostProduct";
+import { useRouter } from "next/router";
 
 function UploadForm() {
   const INITIAL_VALUES = {
@@ -11,7 +13,6 @@ function UploadForm() {
     tag: [],
   };
 
-  // file input 제외한 모든 input
   const [values, setValues] = useState<{
     name: string;
     description: string;
@@ -22,15 +23,21 @@ function UploadForm() {
   const [imgFile, setImgFile] = useState("");
   const [isDisableChk, setIsDisableChk] = useState(true);
 
-  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = new FormData();
+  const router = useRouter();
 
-    formData.append("name", values.name);
-    formData.append("description", values.description);
-    formData.append("price", values.price as string);
-    formData.append("tag", values.tag as any as string);
-    formData.append("images", imgFile);
+  const { mutate: uploadProduct } = usePostProduct();
+
+  const handleSubmit = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    uploadProduct(
+      { values, imgFile },
+      {
+        onSuccess: () => {
+          router.push("/items");
+        },
+      }
+    );
   };
 
   useEffect(() => {
@@ -48,13 +55,14 @@ function UploadForm() {
 
   return (
     <div className={styles.pagiContainer}>
-      <form onSubmit={handleSubmit}>
+      <form>
         <div className={styles.submitContainer}>
           <p className={styles.submitTitle}>상품 등록하기</p>
           <button
             type="button"
             className={styles.btnSubmit}
             disabled={isDisableChk ? true : false}
+            onClick={handleSubmit}
           >
             등록
           </button>

--- a/src/components/items/additem/UploadForm.tsx
+++ b/src/components/items/additem/UploadForm.tsx
@@ -5,7 +5,7 @@ import styles from "./additem.module.css";
 
 function UploadForm() {
   const INITIAL_VALUES = {
-    title: "",
+    name: "",
     description: "",
     price: 0,
     tag: [],
@@ -13,28 +13,29 @@ function UploadForm() {
 
   // file input 제외한 모든 input
   const [values, setValues] = useState<{
-    title: string;
+    name: string;
     description: string;
     price: number | string;
     tag: string[];
   }>(INITIAL_VALUES);
 
-  const [imgFile, setImgFile] = useState<Blob | MediaSource | null>(null);
+  const [imgFile, setImgFile] = useState("");
   const [isDisableChk, setIsDisableChk] = useState(true);
 
-  // 데이터 전송 구현 보류
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData();
-    formData.append("title", values.title);
+
+    formData.append("name", values.name);
     formData.append("description", values.description);
-    formData.append("price", values.price as string | Blob);
+    formData.append("price", values.price as string);
     formData.append("tag", values.tag as any as string);
+    formData.append("images", imgFile);
   };
 
   useEffect(() => {
     if (
-      values.title !== "" &&
+      values.name !== "" &&
       values.description !== "" &&
       Number(values.price) > 0 &&
       values.tag.length > 0

--- a/src/components/items/additem/types.ts
+++ b/src/components/items/additem/types.ts
@@ -6,15 +6,15 @@ export interface PreviewProps {
 
 // RegisterImgFile.tsx
 export interface ImgFileProps {
-  imgFile: Blob | MediaSource | null;
-  setImgFile: React.Dispatch<React.SetStateAction<Blob | MediaSource | null>>;
+  imgFile: string;
+  setImgFile: React.Dispatch<React.SetStateAction<string>>;
 }
 
 // RegisterInput.tsx
 export interface InitialValues {
   setValues: React.Dispatch<
     React.SetStateAction<{
-      title: string;
+      name: string;
       description: string;
       price: number | string;
       tag: string[];

--- a/src/hooks/useGetUser.ts
+++ b/src/hooks/useGetUser.ts
@@ -12,9 +12,9 @@ const fetchUser = async () => {
   }
 };
 
-export function useGetUser() {
+export const useGetUser = () => {
   return useQuery({
     queryKey: ["user"],
     queryFn: fetchUser,
   });
-}
+};

--- a/src/hooks/usePostProduct.ts
+++ b/src/hooks/usePostProduct.ts
@@ -1,7 +1,47 @@
-const fetchProduct = async () => {
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axiosInstance from "../api/axiosInstance";
 
+interface Props {
+  name: string;
+  description: string;
+  price: number | string;
+  tag: string[];
 }
 
-export const usePostProduct = ()=> {
-    
-}
+const fetchProduct = async ({
+  values,
+  imgFile,
+}: {
+  values: Props;
+  imgFile: string;
+}) => {
+
+  const payload = {
+    name: values.name,
+    description: values.description,
+    price: Number(values.price),
+    tags: values.tag,
+    images: [imgFile],
+  };
+
+  try {
+    const response = await axiosInstance.post(`/products`, payload);
+
+    return response.data;
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+};
+
+export const usePostProduct = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: fetchProduct,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["product"],
+      });
+    },
+  });
+};

--- a/src/hooks/usePostProduct.ts
+++ b/src/hooks/usePostProduct.ts
@@ -1,0 +1,7 @@
+const fetchProduct = async () => {
+
+}
+
+export const usePostProduct = ()=> {
+    
+}

--- a/src/hooks/usePostProductImg.ts
+++ b/src/hooks/usePostProductImg.ts
@@ -3,7 +3,7 @@ import axiosInstance from "../api/axiosInstance";
 
 const fetchProductImg = async (previewUrl: Blob) => {
   const formData = new FormData();
-  
+
   formData.append("image", previewUrl);
   try {
     const response = await axiosInstance.post(`/images/upload`, formData, {
@@ -12,7 +12,7 @@ const fetchProductImg = async (previewUrl: Blob) => {
       },
     });
 
-    return response.data;
+    return response.data.url;
   } catch (err) {
     console.error("API 요청 실패:", err);
     throw err;

--- a/src/hooks/usePostProductImg.ts
+++ b/src/hooks/usePostProductImg.ts
@@ -1,0 +1,26 @@
+import { useMutation } from "@tanstack/react-query";
+import axiosInstance from "../api/axiosInstance";
+
+const fetchProductImg = async (previewUrl: Blob) => {
+  const formData = new FormData();
+  
+  formData.append("image", previewUrl);
+  try {
+    const response = await axiosInstance.post(`/images/upload`, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+
+    return response.data;
+  } catch (err) {
+    console.error("API 요청 실패:", err);
+    throw err;
+  }
+};
+
+export const usePostProductImg = () => {
+  return useMutation({
+    mutationFn: fetchProductImg,
+  });
+};

--- a/src/pages/items/additem.tsx
+++ b/src/pages/items/additem.tsx
@@ -3,7 +3,7 @@ import ItemsListNav from "../../components/app/NavBar";
 import UploadForm from "../../components/items/additem/UploadForm";
 import useProtectedPage from "@/src/utils/useProtectedPage";
 
-function addItemPage() {
+function AddItemPage() {
   useProtectedPage();
 
   return (
@@ -17,4 +17,4 @@ function addItemPage() {
   );
 }
 
-export default addItemPage;
+export default AddItemPage;

--- a/src/pages/items/additem.tsx
+++ b/src/pages/items/additem.tsx
@@ -1,8 +1,11 @@
 import Head from "next/head";
 import ItemsListNav from "../../components/app/NavBar";
 import UploadForm from "../../components/items/additem/UploadForm";
+import useProtectedPage from "@/src/utils/useProtectedPage";
 
 function addItemPage() {
+  useProtectedPage();
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## 📌 PR 내용 요약
- 상품 등록 API 연동

## ✨ 작업 내용
- API 전송 코드 기존 훅을 이용한 API 호출 코드에서 React Query로 변경
- 상품 이미지 API 전송을 통한 URL 추출 코드 추가
- 상품 이미지, 이름, 설명, 가격, 태그 등 API로 전송하여 등록 가능

## 🔍 테스트 방법 (선택)
![화면 기록 2025-04-19 오후 8 30 49](https://github.com/user-attachments/assets/09afb305-0acc-4a48-a079-31382165c253)

## 🔗 관련 이슈 (선택)
- Close #7 

## ⚠️ 참고 사항
- 
