### PR TITLE
[상품 상세페이지 - 좋아요] API 연동

### DIFF
--- a/src/api/productApi.ts
+++ b/src/api/productApi.ts
@@ -1,5 +1,4 @@
 import axiosInstance from "./axiosInstance";
-import { CommentDataProps, ProductDataProps } from "./types";
 
 // 베스트/전체 상품 리스트
 export async function getProductData(params = {}) {
@@ -7,39 +6,4 @@ export async function getProductData(params = {}) {
   const res = await axiosInstance.get(`/products?${query}`);
 
   return res.data;
-}
-
-// 디테일 상품 정보
-export async function getProductId(
-  productId: string | string[],
-  setProductData: React.Dispatch<
-    React.SetStateAction<ProductDataProps | undefined>
-  >,
-  setLoading: React.Dispatch<React.SetStateAction<boolean>>
-) {
-  try {
-    const res = await axiosInstance.get(`/products/${productId}`);
-    setProductData(res.data);
-  } catch (err) {
-    console.error(err);
-  } finally {
-    setLoading(false);
-  }
-}
-
-// 디테일 댓글
-export async function getComments(
-  productId: string | string[],
-  setCommentsData: React.Dispatch<
-    React.SetStateAction<CommentDataProps | undefined>
-  >
-) {
-  try {
-    const res = await axiosInstance.get(
-      `/products/${productId}/comments?limit=10`
-    );
-    setCommentsData(res.data);
-  } catch (err) {
-    console.error(err);
-  }
 }

--- a/src/components/items/id/productDetail.module.css
+++ b/src/components/items/id/productDetail.module.css
@@ -222,6 +222,7 @@
   padding: 0 12px;
   border: 1px solid var(--gray-200);
   border-radius: 35px;
+  cursor: pointer;
 }
 
 .favoritCount .count {

--- a/src/hooks/useGetProductDetail.ts
+++ b/src/hooks/useGetProductDetail.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance from "../api/axiosInstance";
+
+const fetchProduct = async (productId: string) => {
+  try {
+    const response = await axiosInstance.get(`/products/${productId}`);
+
+    return response.data;
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+};
+
+export const useGetProductDetail = (productId: string) => {
+  return useQuery({
+    queryKey: ["product", productId],
+    queryFn: () => fetchProduct(productId),
+  });
+};

--- a/src/hooks/usePostLikeProduct.ts
+++ b/src/hooks/usePostLikeProduct.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axiosInstance from "../api/axiosInstance";
+
+const postLike = async (productId: string) => {
+  return await axiosInstance.post(`/products/${productId}/favorite`);
+};
+
+const deleteLike = async (productId: string) => {
+  return await axiosInstance.delete(`/products/${productId}/favorite`);
+};
+
+export const useToggleLike = (productId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (liked: boolean) => {
+      return liked ? deleteLike(productId) : postLike(productId);
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["product", productId] });
+    },
+  });
+};

--- a/src/pages/items/[id].tsx
+++ b/src/pages/items/[id].tsx
@@ -3,18 +3,14 @@ import { useRouter } from "next/router";
 import ProductDetail from "@/src/components/items/id/ProductDetail";
 import NavBar from "@/src/components/app/NavBar";
 import CommentContainer from "@/src/components/items/id/CommentContainer";
-import { getProductId } from "@/src/api/productApi";
-import { ProductDataProps } from "@/src/types/itemTypes";
 import Head from "next/head";
 import useProtectedPage from "@/src/utils/useProtectedPage";
 import useGetProductComments from "@/src/hooks/useGetProductComments";
 import { useScrollPositioning } from "@/src/utils/useScrollPositioning";
 import { useScrollDetector } from "@/src/utils/useScrollDetector";
+import { useGetProductDetail } from "@/src/hooks/useGetProductDetail";
 
 function ProductDetailPage() {
-  const [productData, setProductData] = useState<ProductDataProps>();
-  const [loading, setLoading] = useState(true);
-
   useProtectedPage();
 
   const router = useRouter();
@@ -22,6 +18,8 @@ function ProductDetailPage() {
   const productId = Array.isArray(rawProductId)
     ? rawProductId[0]
     : rawProductId;
+
+  const { data: productData, isLoading:detailLoading } = useGetProductDetail(productId);
 
   const {
     data: comment,
@@ -52,20 +50,13 @@ function ProductDetailPage() {
     }
   });
 
-  // router.isReady 사용 이유: Next.js는 렌더링된 후 쿼리 객체를 채우기 때문에 라우터 필드가 클라리언트 측에서 업데이트 되고 사용할 준비가 되었는지 여부를 먼저 확인해야 한다.
-  // API
-  useEffect(() => {
-    if (!router.isReady) return;
-    getProductId(productId, setProductData, setLoading);
-  }, [router.isReady, productId]);
-
   return (
     <>
       <Head>
         <title>{productData?.name} - 판다마켓</title>
       </Head>
       <NavBar />
-      <ProductDetail productData={productData} loading={loading} />
+      <ProductDetail loading={detailLoading} productId={productId} productData={productData}/>
       <CommentContainer
         productId={productId}
         commentsData={commentsData}


### PR DESCRIPTION
## 📌 PR 내용 요약
- 상품 좋아요 기능 API 연동

## ✨ 작업 내용
- 상품 디테일 페이지 - 좋아요 기능 구현
- 상품 디테일 페이지 - 기존 훅으로 연동했던 GET API를 React Query로 변경

## 🔍 테스트 방법 (선택)
![화면 기록 2025-04-20 오후 8 34 46](https://github.com/user-attachments/assets/539f88fd-600d-425a-854f-a7f342a490fb)

## 🔗 관련 이슈 (선택)
- Close #9 

## ⚠️ 참고 사항
- 좋아요 기능을 React Query로 구현하기 위해서는 기존 데이터를 불러오는 API 호출 방식도 변경이 필요하여 부득이하게 동시 수정되었음
