### PR TITLE
[상품 상세페이지 - 삭제] API 연동

### DIFF
--- a/src/components/items/id/CommentList.tsx
+++ b/src/components/items/id/CommentList.tsx
@@ -7,7 +7,7 @@ import styles from "./productDetail.module.css";
 import { ChangeEvent, useState } from "react";
 import { useGetUser } from "@/src/hooks/useGetUser";
 import { useModalController } from "@/src/utils/useModalController";
-import { DelCommentModal } from "@/src/components/modal/DelCommentModal";
+import { DeleteModal } from "@/src/components/modal/DeleteModal";
 import { UseInfiniteQueryResult } from "@tanstack/react-query";
 import { useClickOutside } from "@/src/utils/useClickOutside";
 import { CommentEdit } from "./CommentEdit";
@@ -44,7 +44,7 @@ function CommentList({ commentsData, productId, refetch }: Props) {
   return (
     <>
       {showModal && (
-        <DelCommentModal
+        <DeleteModal
           productId={productId}
           commentId={commentId}
           isDelProductComment

--- a/src/components/modal/DeleteModal.tsx
+++ b/src/components/modal/DeleteModal.tsx
@@ -2,40 +2,56 @@ import { UseInfiniteQueryResult } from "@tanstack/react-query";
 import ModalContainer from "../app/ModalContainer";
 import styles from "@/styles/app/modal.module.css";
 import useDelProductComments from "@/src/hooks/useDelProductComment";
+import useDelProduct from "@/src/hooks/useDelProduct";
+import { useRouter } from "next/router";
 
 interface Props {
   productId?: string | string[];
   commentId?: number;
+  isDelProduct?: boolean;
   isDelProductComment?: boolean;
   showModal: boolean;
   setShowModal: (value: boolean) => void;
   isModalMessage: string;
-  refetch: UseInfiniteQueryResult["refetch"];
+  refetch?: UseInfiniteQueryResult["refetch"];
 }
 
-export const DelCommentModal = ({
+export const DeleteModal = ({
   productId,
   commentId,
+  isDelProduct,
   isDelProductComment,
   showModal,
   setShowModal,
   isModalMessage,
   refetch,
 }: Props) => {
+  const router = useRouter();
+
+  const { mutate: deleteProduct } = useDelProduct(productId);
   const { mutate: deleteComment } = useDelProductComments(productId!);
 
   const handleConfirmModal = () => {
-    if (!commentId || !productId) return;
+    if (isDelProduct) {
+      if (!productId) return;
 
-    deleteComment(
-      { commentId },
-      {
-        onSuccess: async () => {
-          await refetch();
-          setShowModal(false);
-        },
-      }
-    );
+      deleteProduct();
+      router.replace("/items");
+    }
+
+    if (isDelProductComment) {
+      if (!commentId || !productId) return;
+
+      deleteComment(
+        { commentId },
+        {
+          onSuccess: async () => {
+            if (refetch) await refetch();
+            setShowModal(false);
+          },
+        }
+      );
+    }
   };
 
   return (
@@ -44,14 +60,12 @@ export const DelCommentModal = ({
         <div className={styles.contents}>
           <div className={styles.message}>{isModalMessage}</div>
           <div className={styles.buttonContainer}>
-            {isDelProductComment && (
-              <button
-                className={styles.cancel}
-                onClick={() => setShowModal(false)}
-              >
-                취소
-              </button>
-            )}
+            <button
+              className={styles.cancel}
+              onClick={() => setShowModal(false)}
+            >
+              취소
+            </button>
             <button type="submit" onClick={handleConfirmModal} autoFocus>
               확인
             </button>

--- a/src/hooks/useDelProduct.ts
+++ b/src/hooks/useDelProduct.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axiosInstance from "../api/axiosInstance";
+
+const useDelProduct = (productIdParam: string | string[] | undefined) => {
+  const queryClient = useQueryClient();
+
+  const productId = Array.isArray(productIdParam)
+    ? productIdParam[0]
+    : productIdParam;
+
+  const deleteProduct = async (): Promise<void> => {
+    await axiosInstance.delete(`/products/${productId}`);
+  };
+
+  return useMutation<void, Error, void>({
+    mutationFn: deleteProduct,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["product", productId] });
+    },
+  });
+};
+
+export default useDelProduct;


### PR DESCRIPTION
## 📌 PR 내용 요약
- 내가 등록한 상품을 삭제할 수 있고, 삭제 진행 시 Delete API가 호출되어 리퀘스트와 동시에 상품 리스트 페이지로 이동

## ✨ 작업 내용
- 내가 등록한 상품 삭제하기
- 내가 등록한 상품 상세페이지에 한해 케밥 버튼 활성화

## 🔍 테스트 방법 (선택)
![화면 기록 2025-04-21 오후 9 23 12](https://github.com/user-attachments/assets/4a66aaae-25f7-41d8-80e5-bf535c3ee813)

## 🔗 관련 이슈 (선택)
- Close #8 

## ⚠️ 참고 사항
- useDelProduct.ts의 useMutation에서 API 호출 후 강제 router 이동을 시도했지만, 네트워크 탭의 DELETE -> GET 요청으로 삭제된 데이터를 GET 요청 보내는 버그가 발견되어 useDelProduct의 mutate를 실행 후 router를 이동하도록 코드를 변경하는 과정이 있었음
