### PR TITLE
[자유게시판] 게시글 등록 UIUX 및 로직 구현

### DIFF
--- a/src/components/boards/AllBoard.tsx
+++ b/src/components/boards/AllBoard.tsx
@@ -4,8 +4,9 @@ import WishHeartImg from "@/public/assets/images/boards/ic_heart.svg";
 import { useState } from "react";
 import { Item } from "./types";
 import styles from "./boardList.module.css";
+import { BoardDataProps } from "@/src/types/boardTypes";
 
-function AllBoard({ item }: { item: Item }) {
+function AllBoard({ item }: { item: BoardDataProps }) {
   const [isImgError, setIsImgError] = useState(false);
 
   return (

--- a/src/components/boards/AllBoardsList.tsx
+++ b/src/components/boards/AllBoardsList.tsx
@@ -31,6 +31,8 @@ function AllBoardsList({
     }
   }, [data?.totalCount, isItemCount, setPageCount]);
 
+  console.log(allBoard);
+
   return (
     <>
       <div className={`${styles.postContents} ${styles.allPost}`}>

--- a/src/components/boards/BoardsFilterContainer.tsx
+++ b/src/components/boards/BoardsFilterContainer.tsx
@@ -43,7 +43,7 @@ function BoardsFilterContainer({
     <>
       <div className={styles.titleCover}>
         <p className={styles.listTitle}>게시글</p>
-        <Link href={""}>
+        <Link href={"/boards/add"}>
           <button type="button">글쓰기</button>
         </Link>
       </div>

--- a/src/components/boards/add/InputContainer.tsx
+++ b/src/components/boards/add/InputContainer.tsx
@@ -1,0 +1,31 @@
+import { InitialValues } from "../shared/types";
+import styles from "../shared/form.module.css";
+import { useBoardFormState } from "@/src/hooks/use/useBoardFormState";
+
+function InputContainer({ setValues, uploadLoading }: InitialValues) {
+  const { handleInputChange } = useBoardFormState(setValues);
+
+  return (
+    <fieldset disabled={uploadLoading}>
+      <div className={styles.inputContainer}>
+        <p className={styles.inputTitle}>제목</p>
+        <input
+          name="title"
+          type="text"
+          placeholder="제목을 입력해주세요"
+          onChange={handleInputChange}
+        />
+      </div>
+      <div className={styles.inputContainer}>
+        <p className={styles.inputTitle}>내용</p>
+        <textarea
+          name="content"
+          placeholder="내용을 입력해주세요"
+          onChange={handleInputChange}
+        />
+      </div>
+    </fieldset>
+  );
+}
+
+export default InputContainer;

--- a/src/components/boards/add/UploadForm.tsx
+++ b/src/components/boards/add/UploadForm.tsx
@@ -1,0 +1,53 @@
+import ChooseImgFile from "../shared/ChooseImgFile";
+import styles from "../shared/form.module.css";
+import { useRouter } from "next/router";
+import InputContainer from "./InputContainer";
+import { usePostBoard } from "@/src/hooks/react-query/usePostBoard";
+import { useBoardFormActive } from "@/src/hooks/use/useBoardFormActive";
+import { useBoardForm } from "@/src/hooks/use/useBoardForm";
+
+function UploadForm() {
+  const router = useRouter();
+
+  const { mutate: uploadBoard, isPending: uploadLoading } = usePostBoard();
+
+  const { values, setValues, imgFile, setImgFile } = useBoardForm();
+  const isDisabled = useBoardFormActive(imgFile, values, undefined, "add");
+
+  const handleSubmit = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    uploadBoard(
+      { values, imgFile },
+      {
+        onSuccess: () => {
+          router.push("/boards");
+        },
+      }
+    );
+  };
+
+  console.log(imgFile);
+
+  return (
+    <div className={styles.pagiContainer}>
+      <form>
+        <div className={styles.submitContainer}>
+          <p className={styles.submitTitle}>게시글 쓰기</p>
+          <button
+            type="button"
+            className={styles.btnSubmit}
+            disabled={isDisabled || uploadLoading ? true : false}
+            onClick={handleSubmit}
+          >
+            등록
+          </button>
+        </div>
+        <InputContainer setValues={setValues} uploadLoading={uploadLoading} />
+        <ChooseImgFile imgFile={imgFile} setImgFile={setImgFile} />
+      </form>
+    </div>
+  );
+}
+
+export default UploadForm;

--- a/src/components/boards/shared/ChooseImgFile.tsx
+++ b/src/components/boards/shared/ChooseImgFile.tsx
@@ -1,0 +1,102 @@
+import { ChangeEvent, MouseEvent, useEffect, useRef, useState } from "react";
+import UploadImg from "@/public/assets/images/items/upload.svg";
+import ImgPreview from "./ImgPreview";
+import { ImgFileProps } from "./types";
+import styles from "../shared/form.module.css";
+import { usePostProductImg } from "@/src/hooks/react-query/usePostProductImg";
+
+function ChooseImgFile({ imgFile, setImgFile }: ImgFileProps) {
+  const [previewUrl, setPreviewUrl] = useState<Blob>();
+  const [previewImg, setPreviewImg] = useState("");
+  const [isImgChk, setIsImgChk] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleGetImg = async (e: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = (e?.target as HTMLInputElement).files![0];
+    setPreviewUrl(nextValue);
+    e.target.value = "";
+  };
+
+  const { mutate: uploadImg } = usePostProductImg();
+
+  const handlePreventionClick = (e: MouseEvent) => {
+    if (imgFile) {
+      e.preventDefault();
+      setIsImgChk(true);
+    } else {
+      setIsImgChk(false);
+    }
+  };
+
+  const handleDeleteClick = () => {
+    setIsImgChk(false);
+    setImgFile("");
+    setPreviewImg("");
+    setPreviewUrl(undefined);
+  };
+
+  useEffect(() => {
+    if (imgFile.length > 0) {
+      setPreviewImg(imgFile);
+    } else if (previewUrl) {
+      const nextPreview = URL.createObjectURL(previewUrl);
+      setPreviewImg(nextPreview);
+    }
+  }, [previewUrl, imgFile]);
+
+  useEffect(() => {
+    if (!previewUrl) return;
+
+    uploadImg(previewUrl, {
+      onSuccess: (data) => {
+        setImgFile(data);
+      },
+      onError: (err) => {
+        console.error(err);
+      },
+    });
+  }, [previewUrl, uploadImg, setImgFile]);
+
+  return (
+    <div className={`${styles.inputContainer} ${styles.fileBox}`}>
+      <p className={styles.inputTitle}>이미지</p>
+      <div className={styles.previewContainer}>
+        <div className={styles.coverTile}>
+          <label htmlFor="imgUpload">
+            <div className={styles.cover}>
+              <UploadImg />
+              <p className={styles.imgUpload}>이미지 등록</p>
+            </div>
+          </label>
+          <input
+            id="imgUpload"
+            name="imgFile"
+            type="file"
+            className={styles.btnImgUpload}
+            accept=".jpg, .png"
+            onChange={handleGetImg}
+            ref={inputRef}
+            onClick={handlePreventionClick}
+          />
+        </div>
+        {previewImg && (
+          <div className={`${styles.coverTile} ${styles.thumbnail}`}>
+            <ImgPreview
+              preview={previewImg}
+              handleDeleteClick={handleDeleteClick}
+            />
+          </div>
+        )}
+      </div>
+      {isImgChk ? (
+        <p className={styles.warnMessage}>
+          *이미지 등록은 최대 1개까지 가능합니다.
+        </p>
+      ) : (
+        ""
+      )}
+    </div>
+  );
+}
+
+export default ChooseImgFile;

--- a/src/components/boards/shared/ImgPreview.tsx
+++ b/src/components/boards/shared/ImgPreview.tsx
@@ -1,0 +1,18 @@
+import DeleteBtnImg from "@/public/assets/images/items/cancel.svg";
+import { PreviewProps } from "./types";
+import Image from "next/image";
+import styles from "../shared/form.module.css";
+
+function ImgPreview({ preview, handleDeleteClick }: PreviewProps) {
+
+  return (
+    <>
+      <Image src={preview} alt="상품 이미지 미리보기" fill />
+      <div className={styles.circle} onClick={handleDeleteClick}>
+        <DeleteBtnImg />
+      </div>
+    </>
+  );
+}
+
+export default ImgPreview;

--- a/src/components/boards/shared/form.module.css
+++ b/src/components/boards/shared/form.module.css
@@ -1,0 +1,240 @@
+.pagiContainer {
+  margin-top: 69px;
+  /* Default */
+  padding: 0 200px;
+
+  /* 1920 이상 */
+  @media (min-width: 1920px) {
+    padding: 0;
+    max-width: 1110px;
+    margin: 69px auto 0;
+  }
+  /* Tablet, Mobile */
+  @media (max-width: 1199px) {
+    padding: 0 24px;
+  }
+}
+
+.submitContainer {
+  -webkit-display: flex;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 0;
+}
+
+.submitTitle {
+  font-size: 2em;
+  font-weight: 600;
+}
+
+.btnSubmit {
+  height: 42px;
+  padding: 0 23px;
+  border-radius: 8px;
+  background: var(--primary);
+  color: var(--gray-100);
+  font-size: 1.6em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.btnSubmit:disabled {
+  background: var(--gray-400);
+  cursor: default;
+}
+
+.inputContainer {
+  margin-bottom: 32px;
+}
+
+.inputContainer input::placeholder,
+.inputContainer textarea::placeholder {
+  color: var(--gray-400);
+}
+
+.inputContainer input[type="text"],
+.inputContainer input[type="number"],
+.inputContainer textarea {
+  width: 100%;
+  padding: 16px 24px;
+  border: none;
+  border-radius: 12px;
+  background: var(--gray-100);
+  color: var(--gray-800);
+  font-size: 1.6em;
+}
+
+.inputContainer textarea {
+  height: calc(100vw * (282 / 1100));
+  max-height: 282px;
+}
+
+.inputTitle {
+  margin-bottom: 15px;
+  font-size: 1.8em;
+  font-weight: 600;
+}
+
+.previewContainer {
+  -webkit-display: flex;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  gap: 2%;
+
+  /* Mobile */
+  @media (max-width: 768px) {
+    gap: 2%;
+    justify-content: space-between;
+  }
+}
+
+.previewContainer .coverTile {
+  max-width: 23%;
+  flex: 1;
+
+  /* Mobile */
+  @media (max-width: 768px) {
+    max-width: 48%;
+  }
+}
+
+.inputContainer input[type="file"] {
+  position: absolute;
+  width: 0;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+}
+
+.fileBox label {
+  display: inline-block;
+  border-radius: 12px;
+  color: #fff;
+  cursor: pointer;
+  background: var(--gray-100);
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-height: min-content;
+}
+
+.fileBox label::after {
+  content: "";
+  display: block;
+  padding-bottom: 100%;
+}
+
+.fileBox label .cover {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+}
+
+.fileBox label .cover > img {
+  display: inline-block;
+}
+
+.fileBox label .imgUpload {
+  margin-top: 10px;
+  font-size: 1.6em;
+  font-weight: 300;
+  color: var(--gray-400);
+}
+
+.btnImgUpload {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.tagContainer {
+  -webkit-display: flex;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  margin-top: 15px;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: calc(env(safe-area-inset-bottom) + 100px);
+}
+
+.tagContainer li {
+  -webkit-display: flex;
+  display: flex;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  align-items: center;
+  height: 36px;
+  line-height: 36px;
+  padding: 0 15px;
+  border-radius: 26px;
+  background: var(--gray-100);
+  color: var(--gray-800);
+  font-size: 1.6em;
+  font-weight: 400;
+  letter-spacing: 0.2px;
+}
+
+.circle {
+  margin-left: 8px;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  border-radius: 50%;
+  background: var(--gray-400);
+  text-align: center;
+  cursor: pointer;
+}
+
+.circle > img {
+  display: inline-block;
+}
+
+.previewContainer .thumbnail {
+  position: relative;
+  border: 1px solid var(--gray-50);
+  overflow: hidden;
+  border-radius: 12px;
+  display: inline-block;
+  border-radius: 12px;
+  color: #fff;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-height: min-content;
+}
+.previewContainer .thumbnail::after {
+  content: "";
+  display: block;
+  padding-bottom: 100%;
+}
+
+.previewContainer .thumbnail > img {
+  display: block;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  object-fit: cover;
+  position-area: center;
+}
+
+.thumbnail .circle {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  line-height: 23px;
+}
+
+.warnMessage {
+  margin-top: 15px;
+  color: var(--red);
+  font-size: 1.6em;
+  font-weight: 400;
+}

--- a/src/components/boards/shared/types.ts
+++ b/src/components/boards/shared/types.ts
@@ -1,0 +1,23 @@
+// ImgPreview.tsx
+export interface PreviewProps {
+  preview: string;
+  handleDeleteClick: () => void;
+}
+
+// RegisterImgFile.tsx
+export interface ImgFileProps {
+  imgFile: string;
+  setImgFile: React.Dispatch<React.SetStateAction<string>>;
+}
+
+// RegisterInput.tsx
+export type ValuesItem = {
+  title: string;
+  content: string;
+};
+
+export interface InitialValues {
+  values?: ValuesItem;
+  setValues: React.Dispatch<React.SetStateAction<ValuesItem>>;
+  uploadLoading: boolean;
+}

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -1,6 +1,11 @@
-export const INITIAL_VALUES = {
+export const PRODUCT_INITIAL_VALUES = {
   name: "",
   description: "",
   price: 0,
   tag: [],
+};
+
+export const BOARD_INITIAL_VALUES = {
+  title: "",
+  content: "",
 };

--- a/src/hooks/react-query/useGetBoard.ts
+++ b/src/hooks/react-query/useGetBoard.ts
@@ -1,5 +1,5 @@
 import axiosInstance from "@/src/api/axiosInstance";
-import { BoardList } from "@/src/types/boardTypes";
+import { BoardDataProps, BoardList } from "@/src/types/boardTypes";
 import { useQuery } from "@tanstack/react-query";
 
 const fetchBoard = async (params = {}) => {
@@ -15,7 +15,7 @@ const fetchBoard = async (params = {}) => {
 };
 
 export const useGetBoard = (params = {}) => {
-  return useQuery<{ list: BoardList[]; totalCount: number }>({
+  return useQuery<{ list: BoardDataProps[]; totalCount: number }>({
     queryKey: ["board", params],
     queryFn: () => fetchBoard(params),
   });

--- a/src/hooks/react-query/usePostBoard.ts
+++ b/src/hooks/react-query/usePostBoard.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axiosInstance from "../../api/axiosInstance";
+
+interface Props {
+  title: string;
+  content: string;
+}
+
+const fetchBoard = async ({
+  values,
+  imgFile,
+}: {
+  values: Props;
+  imgFile: string;
+}) => {
+  const payload = {
+    title: values.title,
+    content: values.content,
+    image: imgFile,
+  };
+
+  try {
+    const response = await axiosInstance.post(`/articles`, payload);
+
+    return response.data;
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+};
+
+export const usePostBoard = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: fetchBoard,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["board"],
+      });
+    },
+  });
+};

--- a/src/hooks/use/useBoardForm.ts
+++ b/src/hooks/use/useBoardForm.ts
@@ -1,0 +1,27 @@
+import { BOARD_INITIAL_VALUES } from "@/src/constants/product";
+import { BoardDataProps } from "@/src/types/boardTypes";
+import { useEffect, useState } from "react";
+
+export const useBoardForm = (boardData?: BoardDataProps) => {
+  const [values, setValues] = useState<{
+    title: string;
+    content: string;
+  }>(BOARD_INITIAL_VALUES);
+
+  const [imgFile, setImgFile] = useState("");
+
+  useEffect(() => {
+    if (!boardData) return;
+
+    if (boardData) {
+      setImgFile(boardData?.image);
+      setValues((prevValues) => ({
+        ...prevValues,
+        name: boardData?.title,
+        description: boardData?.content,
+      }));
+    }
+  }, [boardData]);
+
+  return { values, setValues, imgFile, setImgFile };
+};

--- a/src/hooks/use/useBoardFormActive.ts
+++ b/src/hooks/use/useBoardFormActive.ts
@@ -1,0 +1,38 @@
+import { ValuesItem } from "@/src/components/boards/shared/types";
+import { BoardDataProps } from "@/src/types/boardTypes";
+import { useEffect, useState } from "react";
+
+type Mode = "add" | "edit";
+
+export const useBoardFormActive = (
+  imgFile: string,
+  values: ValuesItem,
+  boardData?: BoardDataProps,
+  mode: Mode = "add"
+) => {
+  const [isDisabled, setIsDisabled] = useState(true);
+
+  useEffect(() => {
+    let active = false;
+
+    if (mode === "add") {
+      active =
+        imgFile.length > 0 && values.title !== "" && values.content !== "";
+    }
+
+    if (mode === "edit" && boardData) {
+      const isThumbnailChanged = imgFile !== boardData?.image;
+      const isNameChanged = values.title !== boardData?.title;
+      const isDescChanged = values.content !== boardData?.content;
+      active =
+        imgFile.length > 0 &&
+        values.title !== "" &&
+        values.content !== "" &&
+        (isThumbnailChanged || isNameChanged || isDescChanged);
+    }
+
+    setIsDisabled(!active);
+  }, [imgFile, values, boardData, mode]);
+
+  return isDisabled;
+};

--- a/src/hooks/use/useBoardFormState.ts
+++ b/src/hooks/use/useBoardFormState.ts
@@ -1,0 +1,25 @@
+import { ValuesItem } from "@/src/components/boards/shared/types";
+import { ChangeEvent } from "react";
+
+export const useBoardFormState = (
+  setValues: React.Dispatch<React.SetStateAction<ValuesItem>>
+) => {
+  const handleChange = (name: string, value: string | number | string[]) => {
+    setValues((prevValue) => ({
+      ...prevValue,
+      [name]: value,
+    }));
+  };
+
+  const handleInputChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    let { name, value }: { name: string; value: string | number | string[] } =
+      e.target;
+    handleChange(name, value);
+  };
+
+  return {
+    handleInputChange,
+  };
+};

--- a/src/hooks/use/useProductForm.ts
+++ b/src/hooks/use/useProductForm.ts
@@ -1,4 +1,4 @@
-import { INITIAL_VALUES } from "@/src/constants/product";
+import { PRODUCT_INITIAL_VALUES } from "@/src/constants/product";
 import { ProductDataProps } from "@/src/types/itemTypes";
 import { useEffect, useState } from "react";
 
@@ -8,7 +8,7 @@ export const useProductForm = (productData?: ProductDataProps) => {
     description: string;
     price: number | string;
     tag: string[];
-  }>(INITIAL_VALUES);
+  }>(PRODUCT_INITIAL_VALUES);
 
   const [imgFile, setImgFile] = useState("");
 

--- a/src/pages/boards/add.tsx
+++ b/src/pages/boards/add.tsx
@@ -1,0 +1,20 @@
+import Head from "next/head";
+import ItemsListNav from "../../components/app/NavBar";
+import useProtectedPage from "@/src/hooks/use/useProtectedPage";
+import UploadForm from "@/src/components/boards/add/UploadForm";
+
+function AddBoardPage() {
+  useProtectedPage();
+
+  return (
+    <>
+      <Head>
+        <title>게시글 등록 - 판다마켓</title>
+      </Head>
+      <ItemsListNav />
+      <UploadForm />
+    </>
+  );
+}
+
+export default AddBoardPage;

--- a/src/types/boardTypes.ts
+++ b/src/types/boardTypes.ts
@@ -1,6 +1,15 @@
-import { StaticImport } from "next/dist/shared/lib/get-img-props";
+export interface BoardDataProps {
+  id: number;
+  title: string;
+  content: string;
+  image: string;
+  writer: boardWriter[];
+  likeCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
 
-interface ItemWriter {
+interface boardWriter {
   id: number;
   nickname: string;
 }
@@ -9,9 +18,5 @@ export interface BoardList {
   id: number;
   title: string;
   content: string;
-  createdAt: string;
-  updatedAt: string;
-  image: string | StaticImport;
-  likeCount: number;
-  writer: ItemWriter;
+  image: string;
 }

--- a/src/types/boardTypes.ts
+++ b/src/types/boardTypes.ts
@@ -1,17 +1,17 @@
+interface boardWriter {
+  id: number;
+  nickname: string;
+}
+
 export interface BoardDataProps {
   id: number;
   title: string;
   content: string;
   image: string;
-  writer: boardWriter[];
+  writer: boardWriter;
   likeCount: number;
   createdAt: string;
   updatedAt: string;
-}
-
-interface boardWriter {
-  id: number;
-  nickname: string;
 }
 
 export interface BoardList {

--- a/src/types/itemTypes.ts
+++ b/src/types/itemTypes.ts
@@ -1,5 +1,3 @@
-import { StaticImport } from "next/dist/shared/lib/get-img-props";
-
 export interface ParamsId {
   productId: string | undefined;
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 자유게시판 게시글 등록 로직 구현

## ✨ 작업 내용
- 게시글 등록하기 UIUX
- 등록 API 연동
- 추후 '수정하기' 측 공동 로직 추가 구현

## 🔍 테스트 방법 (선택)
![화면 기록 2025-08-27 오후 3 58 54](https://github.com/user-attachments/assets/ed780796-a961-4b0f-9aea-59b9f9c1b25e)

## 🔗 관련 이슈 (선택)
- Close #17 #18 

## ⚠️ 참고 사항
- RHF을 사용하지 않고, 기존의 '상품 등록하기' 로직과 동일하게 하드 코딩으로 구현함
